### PR TITLE
Allows for a pre-round purchasable for removing legs

### DIFF
--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -367,7 +367,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 							H.limbs.l_leg.delete()
 						if (H.limbs.r_leg)
 							H.limbs.r_leg.delete()
-						boutput( H, "<span class='notice'><b>You haven't got a leg to stand on</b></span>" )
+						boutput( H, "<span class='notice'><b>You haven't got a leg to stand on!</b></span>" )
 				return 1
 			return 0
 
@@ -596,5 +596,4 @@ var/global/list/persistent_bank_purchaseables =	list(\
 				A.set_hat(new picked())
 				return 1
 			return 0
-
 

--- a/code/modules/economy/persistent_bank_purchases.dm
+++ b/code/modules/economy/persistent_bank_purchases.dm
@@ -28,6 +28,7 @@ var/global/list/persistent_bank_purchaseables =	list(\
 	new /datum/bank_purchaseable/nt_backpack,\
 
 	new /datum/bank_purchaseable/limbless,\
+	new /datum/bank_purchaseable/legless,\
 	new /datum/bank_purchaseable/corpse,\
 	new /datum/bank_purchaseable/space_diner,\
 	new /datum/bank_purchaseable/mail_order,\
@@ -350,6 +351,23 @@ var/global/list/persistent_bank_purchaseables =	list(\
 						if (H.limbs.r_leg)
 							H.limbs.r_leg.delete()
 						boutput( H, "<span class='notice'><b>Your limbs magically disappear! Oh, no!</b></span>" )
+				return 1
+			return 0
+
+	legless
+		name = "No Legs"
+		cost = 5000
+
+		Create(var/mob/living/M)
+			if (ishuman(M))
+				var/mob/living/carbon/human/H = M
+				SPAWN_DBG(6 SECONDS)
+					if (H.limbs)
+						if (H.limbs.l_leg)
+							H.limbs.l_leg.delete()
+						if (H.limbs.r_leg)
+							H.limbs.r_leg.delete()
+						boutput( H, "<span class='notice'><b>You haven't got a leg to stand on</b></span>" )
 				return 1
 			return 0
 


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- To automatically tag this PR, add the uppercase label(s) surrounded by brackets below, for example: [LABEL] -->
[FEATURE]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR allows for a Spacebux purchasable option for stating without legs.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
This is needed to allow for those who want to start without legs, to not have to rush to medbay while they are preparing, or to have to start arms either.


## Changelog
<!-- If necessary, put your changelog entry below. Otherwise, please delete it.
Use however you want to be credited in the changelog in place of CodeDude.
Use (*) for major changes and (+) for minor changes. For example: -->

```
(u)Yellow-Mushroom:
(*)Added legless purchasable to Spacebux menu

